### PR TITLE
 On branch ctrl_leftbracket

### DIFF
--- a/dmenu.c
+++ b/dmenu.c
@@ -261,6 +261,7 @@ keypress(XKeyEvent *ev) {
 			ksym = XK_Left;
 			break;
 		case XK_c:
+		case XK_bracketleft:
 			ksym = XK_Escape;
 			break;
 		case XK_d:


### PR DESCRIPTION
	modified:   dmenu.c
		added a key binding for ^bracketleft to do the same thing as ^c
		(thats the VT100 code for escape, its nice to use when escape button is far away. I like to replicate the behavior here)